### PR TITLE
Config Fixes, Options for X-Pack and Security, and Expanding ES and LS Clusters

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,20 @@
-VER=6.5.3
+VER=6.5.4
 CLUSTER=docker-es-cluster
-JVM_MEM=1g
+ES_NODE_JVM_HEAP_MEM=1536m
+LS_NODE_JVM_HEAP_MEM=1536m
 ES_NODE_PREFIX=es-node
+LS_NODE_PREFIX=ls-node
 PUBLIC_ELASTIC_PORT=9200
 PUBLIC_KIBANA_PORT=5601
+# If you want to enable security, set XPACK_SECURITY_ENABLED=true, and XPACK_LICENSE_SELF_GENERATED_TYPE=trial
+# Security enabling is required if central management of logstash pipelines is desired (which also requires XPACK_MANAGEMENT_ENABLED=true for logstash containers)
+XPACK_SECURITY_ENABLED=false
+XPACK_MONITORING_ENABLED=true
+XPACK_MANAGEMENT_ENABLED=false
+XPACK_LICENSE_SELF_GENERATED_TYPE=basic
+ELASTIC_USERNAME=elastic
+KIBANA_USERNAME=elastic
+LOGSTASH_USERNAME=elastic
+ELASTIC_PASSWORD=changeme
+# Comma-separated list of centrally managed logstash pipelines
+LOGSTASH_MANAGED_PIPELINES=

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Quickly spin up a Docker cluster of Elastic products for testing
 ## Quickstart
 
 Default configuration will create a three node cluster with an additional kibana node.
-The nodes will use the latest stable version 6.5.3 at the time of writing.
+The nodes will use the latest stable version 6.5.4 at the time of writing.
 Some configs are stored in .env
 
 1. (Assuming you already have docker installed and running)
@@ -34,8 +34,39 @@ Some configs are stored in .env
     - `logstash-2015.05.19`
     - `logstash-2015.05.20`
 
+## Trying Out Security and other X-Pack Features
+Changing the following `.env` config values, and cleanly refreshing your cluster (see below), will enable the trial version of the (platinum) X-Pack features, including security.
+
+```bash
+XPACK_SECURITY_ENABLED=true
+XPACK_MANAGEMENT_ENABLED=true
+XPACK_LICENSE_SELF_GENERATED_TYPE=trial
+```
+
+Once up and running, use the `ELASTIC_USERNAME` and `ELASTIC_PASSWORD` env variable values to login.
+
+## Cleanup or Fresh Restart
+When you stop the containers with CTRL-C, they still exist in a stopped state as well as their volumes. Doing `docker-compose up` again, will just restart those containers, and reuse the data in those volumes. 
+
+That may be what you want. However, if you want to start fresh, with know persisted data, state, or configuration, remove the stopped containers and volumes using the below command
+
+:warning: This will remove _any_ container you have from org `docker.elastic.co`. Adjust the `grep` pattern as needed.
+
+```docker ps -a | grep "docker.elastic.co" | awk '{print $1}' | xargs docker rm```
+
+To remove the volumes, run
+
+```docker volume ls | grep "esdata" | awk '{print $2}' | xargs docker volume rm```
 
 ## Troubleshooting
+
+### Not able to switch between basic and trial (platinum) licenses
+_If you reconfigure the license configuration in `docker-compose.yaml`, and restart the containers, it is not always picked up. This information appears to be persisted in the volumes. So you need to remove the volumes as shown below or above.
+
+:warning: this will also remove your indexed data.
+
+If you want to keep your indexes but change your license, do it through the Kibana UI: _Management > Elasticsearch > License Management_
+
 ### Docker volume trouble
 1. List volumes: ```docker volume ls```
-2. Delete the esdata* volumes: ```docker volume rm elastisch-schwarm_esdata0 ``` etc.
+2. Delete the `*esdata*` volumes: ```docker volume ls | grep "esdata" | awk '{print $2}' | xargs docker volume rm```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Quickly spin up a Docker cluster of Elastic products for testing
 
 ## Quickstart
 
-Default configuration will create a three node cluster with an additional kibana node.
+Default configuration will create a three node Elasticsearch cluster with a three node Logstash cluster and an additional Kibana node. _(Comment-out or delete entire service blocks in `docker-compose.yaml` to reduce the number of nodes in these clusters.)_
+
+
 The nodes will use the latest stable version 6.5.4 at the time of writing.
 Some configs are stored in .env
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Default configuration will create a three node Elasticsearch cluster with a thre
 The nodes will use the latest stable version 6.5.4 at the time of writing.
 Some configs are stored in .env
 
-1. (Assuming you already have docker installed and running)
+1. (Assuming you already have docker installed and running, with enough [memory](#containers-die-randomly-without-clear-errors) allocated)
 ```$ docker-compose up```
 2. Click [http://localhost:5601](http://localhost:5601)
 3. ....
@@ -61,6 +61,9 @@ To remove the volumes, run
 ```docker volume ls | grep "esdata" | awk '{print $2}' | xargs docker volume rm```
 
 ## Troubleshooting
+
+### Containers Die Randomly without Clear Errors
+Docker is known to just kill containers ungracefully if it does not have enough memory. With many containers running as part of these clusters the default configuration is known to work with Docker Desktop (on Mac: Docker > Preferences > Advanced) at **6 CPUs** and **12 GiB** of memory.
 
 ### Not able to switch between basic and trial (platinum) licenses
 _If you reconfigure the license configuration in `docker-compose.yaml`, and restart the containers, it is not always picked up. This information appears to be persisted in the volumes. So you need to remove the volumes as shown below or above.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,43 +1,31 @@
 version: '3.2'
 services:
-  es-node-0:
-    hostname: ${ES_NODE_PREFIX}-0
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VER}
-    container_name: ${ES_NODE_PREFIX}-0
-    environment:
-      - cluster.name=${CLUSTER}
-      - node.name=${ES_NODE_PREFIX}-0
-      - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms${JVM_MEM} -Xmx${JVM_MEM}"
-      - "discovery.zen.ping.unicast.hosts=[ ${ES_NODE_PREFIX}-0, ${ES_NODE_PREFIX}-1, ${ES_NODE_PREFIX}-2 ]"
-      - "discovery.zen.minimum_master_nodes: 2"
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-    volumes:
-      - esdata0:/usr/share/elasticsearch/data
-    ports:
-      - 9200:${PUBLIC_ELASTIC_PORT}
-    networks:
-      - esnet
   es-node-1:
     hostname: ${ES_NODE_PREFIX}-1
     image: docker.elastic.co/elasticsearch/elasticsearch:${VER}
     container_name: ${ES_NODE_PREFIX}-1
     environment:
       - cluster.name=${CLUSTER}
+      - network.host=0.0.0.0
       - node.name=${ES_NODE_PREFIX}-1
       - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms${JVM_MEM} -Xmx${JVM_MEM}"
-      - "discovery.zen.ping.unicast.hosts=[ ${ES_NODE_PREFIX}-0, ${ES_NODE_PREFIX}-1, ${ES_NODE_PREFIX}-2 ]"
-      - "discovery.zen.minimum_master_nodes: 2"
+      - "ES_JAVA_OPTS=-Xms${ES_NODE_JVM_HEAP_MEM} -Xmx${ES_NODE_JVM_HEAP_MEM}"
+      - "discovery.zen.ping.unicast.hosts=${ES_NODE_PREFIX}-1,${ES_NODE_PREFIX}-2,${ES_NODE_PREFIX}-3"
+      - discovery.zen.minimum_master_nodes=2
+      - xpack.monitoring.collection.enabled=true
+      # Enabling security is required to use centralized logstash pipelines
+      # And license type needs to be upgraded from "basic" to "trial" in order to enable security
+      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
+      - xpack.license.self_generated.type=${XPACK_LICENSE_SELF_GENERATED_TYPE}  
+      - xpack.security.enabled=${XPACK_SECURITY_ENABLED}
     ulimits:
       memlock:
         soft: -1
         hard: -1
     volumes:
       - esdata1:/usr/share/elasticsearch/data
+    ports:
+      - 9200:${PUBLIC_ELASTIC_PORT}
     networks:
       - esnet
   es-node-2:
@@ -46,11 +34,18 @@ services:
     container_name: ${ES_NODE_PREFIX}-2
     environment:
       - cluster.name=${CLUSTER}
+      - network.host=0.0.0.0
       - node.name=${ES_NODE_PREFIX}-2
       - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms${JVM_MEM} -Xmx${JVM_MEM}"
-      - "discovery.zen.ping.unicast.hosts=[ ${ES_NODE_PREFIX}-0, ${ES_NODE_PREFIX}-1, ${ES_NODE_PREFIX}-2 ]"
-      - "discovery.zen.minimum_master_nodes: 2"
+      - "ES_JAVA_OPTS=-Xms${ES_NODE_JVM_HEAP_MEM} -Xmx${ES_NODE_JVM_HEAP_MEM}"
+      - "discovery.zen.ping.unicast.hosts=${ES_NODE_PREFIX}-1,${ES_NODE_PREFIX}-2,${ES_NODE_PREFIX}-3"
+      - discovery.zen.minimum_master_nodes=2
+      - xpack.monitoring.collection.enabled=true
+      # Enabling security is required to use centralized logstash pipelines
+      # And license type needs to be upgraded from "basic" to "trial" in order to enable security
+      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
+      - xpack.license.self_generated.type=${XPACK_LICENSE_SELF_GENERATED_TYPE}  
+      - xpack.security.enabled=${XPACK_SECURITY_ENABLED}
     ulimits:
       memlock:
         soft: -1
@@ -59,47 +54,170 @@ services:
       - esdata2:/usr/share/elasticsearch/data
     networks:
       - esnet
+  es-node-3:
+    hostname: ${ES_NODE_PREFIX}-3
+    image: docker.elastic.co/elasticsearch/elasticsearch:${VER}
+    container_name: ${ES_NODE_PREFIX}-3
+    environment:
+      - cluster.name=${CLUSTER}
+      - network.host=0.0.0.0
+      - node.name=${ES_NODE_PREFIX}-3
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms${ES_NODE_JVM_HEAP_MEM} -Xmx${ES_NODE_JVM_HEAP_MEM}"
+      - "discovery.zen.ping.unicast.hosts=${ES_NODE_PREFIX}-1,${ES_NODE_PREFIX}-2,${ES_NODE_PREFIX}-3"
+      - discovery.zen.minimum_master_nodes=2
+      - xpack.monitoring.collection.enabled=true
+      # Enabling security is required to use centralized logstash pipelines
+      # And license type needs to be upgraded from "basic" to "trial" in order to enable security
+      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
+      - xpack.license.self_generated.type=${XPACK_LICENSE_SELF_GENERATED_TYPE} 
+      - xpack.security.enabled=${XPACK_SECURITY_ENABLED}
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - esdata3:/usr/share/elasticsearch/data
+    networks:
+      - esnet
   kibana:
     image: docker.elastic.co/kibana/kibana:${VER}
     container_name: kibana
     environment:
-      SERVER_NAME: kibana.local
-      ELASTICSEARCH_URL: http://${ES_NODE_PREFIX}-0:${PUBLIC_ELASTIC_PORT}
+      # NOTE: Kibana env vars DO NOT take the YAML dotted syntax from kibana.yml. Uppercase and underscore in place of dots.
+      - SERVER_NAME=kibana.local
+      - ELASTICSEARCH_URL=http://${ES_NODE_PREFIX}-1:${PUBLIC_ELASTIC_PORT}
+      - ELASTICSEARCH_USERNAME=${KIBANA_USERNAME}
+      - ELASTICSEARCH_PASSWORD=${ELASTIC_PASSWORD}
+      #- XPACK_SECURITY_ENABLED=${XPACK_SECURITY_ENABLED}
+      #- xpack.license.self_generated.type=${XPACK_LICENSE_SELF_GENERATED_TYPE} 
+      #- elasticsearch.username=${KIBANA_USERNAME}
+      #- elasticsearch.password=${ELASTIC_PASSWORD}
+      - XPACK_MONITORING_ELASTICSEARCH_USERNAME=${KIBANA_USERNAME}
+      - XPACK_MONITORING_ELASTICSEARCH_PASSWORD=${ELASTIC_PASSWORD}
+      # Logging
+      #- LOGGING_VERBOSE=true
+      #- LOGGING_LOG_QUERIES=true
     ports:
       - 5601:${PUBLIC_KIBANA_PORT}
     networks:
       - esnet
     depends_on:
-      - ${ES_NODE_PREFIX}-0
+      - ${ES_NODE_PREFIX}-1
   # filebeat:
   #   image: docker.elastic.co/filebeat/filebeat:${VER}
   #   container_name: filebeat
   #   environment:
   #     - SERVER_NAME=filebeat.local
   #     - setup.kibana.host=kibana:${PUBLIC_KIBANA_PORT}
-  #     - output.elasticsearch.hosts=[${ES_NODE_PREFIX}-0:${PUBLIC_ELASTIC_PORT}]
+  #     - output.elasticsearch.hosts=[${ES_NODE_PREFIX}-1:${PUBLIC_ELASTIC_PORT}]
   #   networks:
   #     - esnet
   #   depends_on:
   #     - kibana
-  # logstash:
-  #   image: docker.elastic.co/logstash/logstash:${VER}
-  #   container_name: logstash
-  #   environment:
-  #     - SERVER_NAME=logstash.local
-  #     - setup.kibana.host=kibana:${PUBLIC_KIBANA_PORT}
-  #     - output.elasticsearch.hosts=[${ES_NODE_PREFIX}-0:${PUBLIC_ELASTIC_PORT}]
-  #   networks:
-  #     - esnet
-  #   depends_on:
-  #     - kibana
+  ls-node-1:
+    image: docker.elastic.co/logstash/logstash:${VER}
+    container_name: ${LS_NODE_PREFIX}-1
+    environment:
+      - SERVER_NAME=${LS_NODE_PREFIX}-1
+      - node.name=${LS_NODE_PREFIX}-1
+      - setup.kibana.host=kibana:${PUBLIC_KIBANA_PORT}
+      - output.elasticsearch.hosts=[${ES_NODE_PREFIX}-1:${PUBLIC_ELASTIC_PORT},${ES_NODE_PREFIX}-2:${PUBLIC_ELASTIC_PORT},${ES_NODE_PREFIX}-3:${PUBLIC_ELASTIC_PORT}]
+      - "LS_JAVA_OPTS=-Xms${LS_NODE_JVM_HEAP_MEM} -Xmx${LS_NODE_JVM_HEAP_MEM}"
+      # (https://www.elastic.co/guide/en/logstash/6.5/logstash-monitoring-overview.html): 
+      #   Unlike X-Pack monitoring for Elasticsearch and Kibana, there is no 
+      #   xpack.monitoring.collection.enabled setting on Logstash. You must use the
+      #   xpack.monitoring.enabled setting to enable and disable data collection.
+      - xpack.monitoring.enabled=${XPACK_MONITORING_ENABLED}
+      - xpack.monitoring.elasticsearch.url=[http://${ES_NODE_PREFIX}-1:${PUBLIC_ELASTIC_PORT},http://${ES_NODE_PREFIX}-2:${PUBLIC_ELASTIC_PORT},http://${ES_NODE_PREFIX}-3:${PUBLIC_ELASTIC_PORT}]
+      - xpack.monitoring.elasticsearch.username=${LOGSTASH_USERNAME}
+      - xpack.monitoring.elasticsearch.password=${ELASTIC_PASSWORD}      
+      # Enabling Centralized Configuration Management of Logstash: https://www.elastic.co/guide/en/logstash/current/configuring-centralized-pipelines.html
+      - xpack.management.enabled=${XPACK_MANAGEMENT_ENABLED}
+      - xpack.management.elasticsearch.url=[http://${ES_NODE_PREFIX}-1:${PUBLIC_ELASTIC_PORT},http://${ES_NODE_PREFIX}-2:${PUBLIC_ELASTIC_PORT},http://${ES_NODE_PREFIX}-3:${PUBLIC_ELASTIC_PORT}]
+      # Enabling security is required to use centralized logstash pipelines
+      - xpack.management.elasticsearch.username=${LOGSTASH_USERNAME}
+      - xpack.management.elasticsearch.password=${ELASTIC_PASSWORD} 
+      - xpack.management.logstash.poll_interval=15s
+      - xpack.management.pipeline.id=[${LOGSTASH_MANAGED_PIPELINES}]
+    networks:
+      - esnet
+    depends_on:
+      - kibana
+      - ${ES_NODE_PREFIX}-1
+      - ${ES_NODE_PREFIX}-2
+      - ${ES_NODE_PREFIX}-3
+  ls-node-2:
+    image: docker.elastic.co/logstash/logstash:${VER}
+    container_name: ${LS_NODE_PREFIX}-2
+    environment:
+      - SERVER_NAME=${LS_NODE_PREFIX}-2
+      - node.name=${LS_NODE_PREFIX}-2
+      - setup.kibana.host=kibana:${PUBLIC_KIBANA_PORT}
+      - output.elasticsearch.hosts=[${ES_NODE_PREFIX}-1:${PUBLIC_ELASTIC_PORT},${ES_NODE_PREFIX}-2:${PUBLIC_ELASTIC_PORT},${ES_NODE_PREFIX}-3:${PUBLIC_ELASTIC_PORT}]
+      - "LS_JAVA_OPTS=-Xms${LS_NODE_JVM_HEAP_MEM} -Xmx${LS_NODE_JVM_HEAP_MEM}"
+      # (https://www.elastic.co/guide/en/logstash/6.5/logstash-monitoring-overview.html): 
+      #   Unlike X-Pack monitoring for Elasticsearch and Kibana, there is no 
+      #   xpack.monitoring.collection.enabled setting on Logstash. You must use the
+      #   xpack.monitoring.enabled setting to enable and disable data collection.
+      - xpack.monitoring.enabled=${XPACK_MONITORING_ENABLED}
+      - xpack.monitoring.elasticsearch.url=[http://${ES_NODE_PREFIX}-1:${PUBLIC_ELASTIC_PORT},http://${ES_NODE_PREFIX}-2:${PUBLIC_ELASTIC_PORT},http://${ES_NODE_PREFIX}-3:${PUBLIC_ELASTIC_PORT}]
+      - xpack.monitoring.elasticsearch.username=${LOGSTASH_USERNAME}
+      - xpack.monitoring.elasticsearch.password=${ELASTIC_PASSWORD}      
+      # Enabling Centralized Configuration Management of Logstash: https://www.elastic.co/guide/en/logstash/current/configuring-centralized-pipelines.html
+      - xpack.management.enabled=${XPACK_MANAGEMENT_ENABLED}
+      - xpack.management.elasticsearch.url=[http://${ES_NODE_PREFIX}-1:${PUBLIC_ELASTIC_PORT},http://${ES_NODE_PREFIX}-2:${PUBLIC_ELASTIC_PORT},http://${ES_NODE_PREFIX}-3:${PUBLIC_ELASTIC_PORT}]
+      # Enabling security is required to use centralized logstash pipelines
+      - xpack.management.elasticsearch.username=${LOGSTASH_USERNAME}
+      - xpack.management.elasticsearch.password=${ELASTIC_PASSWORD} 
+      - xpack.management.logstash.poll_interval=15s
+      - xpack.management.pipeline.id=[${LOGSTASH_MANAGED_PIPELINES}]
+    networks:
+      - esnet
+    depends_on:
+      - kibana
+      - ${ES_NODE_PREFIX}-1
+      - ${ES_NODE_PREFIX}-2
+      - ${ES_NODE_PREFIX}-3
+  ls-node-3:
+    image: docker.elastic.co/logstash/logstash:${VER}
+    container_name: ${LS_NODE_PREFIX}-3
+    environment:
+      - SERVER_NAME=${LS_NODE_PREFIX}-3
+      - node.name=${LS_NODE_PREFIX}-3
+      - setup.kibana.host=kibana:${PUBLIC_KIBANA_PORT}
+      - output.elasticsearch.hosts=[${ES_NODE_PREFIX}-1:${PUBLIC_ELASTIC_PORT},${ES_NODE_PREFIX}-2:${PUBLIC_ELASTIC_PORT},${ES_NODE_PREFIX}-3:${PUBLIC_ELASTIC_PORT}]
+      - "LS_JAVA_OPTS=-Xms${LS_NODE_JVM_HEAP_MEM} -Xmx${LS_NODE_JVM_HEAP_MEM}"
+      # (https://www.elastic.co/guide/en/logstash/6.5/logstash-monitoring-overview.html): 
+      #   Unlike X-Pack monitoring for Elasticsearch and Kibana, there is no 
+      #   xpack.monitoring.collection.enabled setting on Logstash. You must use the
+      #   xpack.monitoring.enabled setting to enable and disable data collection.
+      - xpack.monitoring.enabled=${XPACK_MONITORING_ENABLED}
+      - xpack.monitoring.elasticsearch.url=[http://${ES_NODE_PREFIX}-1:${PUBLIC_ELASTIC_PORT},http://${ES_NODE_PREFIX}-2:${PUBLIC_ELASTIC_PORT},http://${ES_NODE_PREFIX}-3:${PUBLIC_ELASTIC_PORT}]
+      - xpack.monitoring.elasticsearch.username=${LOGSTASH_USERNAME}
+      - xpack.monitoring.elasticsearch.password=${ELASTIC_PASSWORD}      
+      # Enabling Centralized Configuration Management of Logstash: https://www.elastic.co/guide/en/logstash/current/configuring-centralized-pipelines.html
+      - xpack.management.enabled=${XPACK_MANAGEMENT_ENABLED}
+      - xpack.management.elasticsearch.url=[http://${ES_NODE_PREFIX}-1:${PUBLIC_ELASTIC_PORT},http://${ES_NODE_PREFIX}-2:${PUBLIC_ELASTIC_PORT},http://${ES_NODE_PREFIX}-3:${PUBLIC_ELASTIC_PORT}]
+      # Enabling security is required to use centralized logstash pipelines
+      - xpack.management.elasticsearch.username=${LOGSTASH_USERNAME}
+      - xpack.management.elasticsearch.password=${ELASTIC_PASSWORD} 
+      - xpack.management.logstash.poll_interval=15s
+      - xpack.management.pipeline.id=[${LOGSTASH_MANAGED_PIPELINES}]
+    networks:
+      - esnet
+    depends_on:
+      - kibana
+      - ${ES_NODE_PREFIX}-1
+      - ${ES_NODE_PREFIX}-2
+      - ${ES_NODE_PREFIX}-3
 
 volumes:
-  esdata0:
-    driver: local
   esdata1:
     driver: local
   esdata2:
+    driver: local
+  esdata3:
     driver: local
 
 networks:


### PR DESCRIPTION
**Overview**
Driven primarily by a desire to see if a clustered set of Logstash nodes could load-balance a heavy-ingest of data ... Added more logstash nodes, increased memory, then added and fixed the necessary configuration to enable security and management features of X-Pack (like centralized management of logstash pipelines).

The default configuration is with security and logstash central management off, but with monitoring turned on by default. The `README.md` explains other options.

**Technical Details**
- Upgrade to ES 6.5.4 from 6.5.3
- Separate out Elasticsearch and Logstash JVM heap size env vars
- Set all heap env vars to 1.5 GB (1536m) initially (and added note in `README.md` about expanding memory on Docker Desktop)
- Enable X-Pack using `XPACK_LICENSE_SELF_GENERATED_TYPE` env var with options of `basic` or `trial`
- Set bootstrap elastic username and password, and strap these to the Logstash and Kibana services by default as well
- Started ES and LS Node and volume indexing at 1 instead of 0
- Turned on Monitoring by default, of both Elasticsearch and Logstash nodes
- Added 3 clustered Logstash nodes by default
- Fixed `discovery.zen.minimum_master_nodes` env var declaration in `docker-compose.yaml`
- Changes single logstash ES output hosts to multiple
- Updated `README.md` to document how to utilize the changes
